### PR TITLE
Assigment2-Implement EC2 Automation with IAM Roles and S3 Log

### DIFF
--- a/aws-log-automation/main.tf
+++ b/aws-log-automation/main.tf
@@ -43,4 +43,102 @@ resource "aws_s3_bucket" "logs_bucket" {
 resource "aws_iam_role" "readonly_role" {
   name = "readonly-s3-role"
   assume_role_policy = jsonencode({
-    Versi
+    Version = "2012-10-17",
+    Statement = [
+      {
+        Effect = "Allow",
+        Principal = {
+          AWS = "*"
+        },
+        Action = "sts:AssumeRole"
+      }
+    ]
+  })
+}
+
+resource "aws_iam_policy" "readonly_s3_policy" {
+  name = "readonly-s3-policy"
+  policy = jsonencode({
+    Version = "2012-10-17",
+    Statement = [
+      {
+        Effect = "Allow",
+        Action = ["s3:ListBucket"],
+        Resource = ["arn:aws:s3:::${var.bucket_name}"]
+      },
+      {
+        Effect = "Allow",
+        Action = ["s3:GetObject"],
+        Resource = ["arn:aws:s3:::${var.bucket_name}/*"]
+      }
+    ]
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "attach_readonly_policy" {
+  role       = aws_iam_role.readonly_role.name
+  policy_arn = aws_iam_policy.readonly_s3_policy.arn
+}
+
+# Write-only Role
+resource "aws_iam_role" "writeonly_role" {
+  name = "writeonly-s3-role"
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17",
+    Statement = [
+      {
+        Effect = "Allow",
+        Principal = {
+          Service = "ec2.amazonaws.com"
+        },
+        Action = "sts:AssumeRole"
+      }
+    ]
+  })
+}
+
+resource "aws_iam_policy" "writeonly_s3_policy" {
+  name = "writeonly-s3-policy"
+  policy = jsonencode({
+    Version = "2012-10-17",
+    Statement = [
+      {
+        Effect = "Allow",
+        Action = [
+          "s3:PutObject",
+          "s3:PutObjectAcl"
+        ],
+        Resource = ["arn:aws:s3:::${var.bucket_name}/*"]
+      },
+      {
+        Effect = "Allow",
+        Action = [
+          "s3:CreateBucket"
+        ],
+        Resource = ["*"]
+      }
+    ]
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "attach_writeonly_policy" {
+  role       = aws_iam_role.writeonly_role.name
+  policy_arn = aws_iam_policy.writeonly_s3_policy.arn
+}
+
+resource "aws_iam_instance_profile" "ec2_instance_profile" {
+  name = "ec2-instance-profile"
+  role = aws_iam_role.writeonly_role.name
+}
+
+# EC2 Instance
+resource "aws_instance" "app_instance" {
+  ami                    = "ami-0c94855ba95c71c99"  # Amazon Linux 2 (us-east-1)
+  instance_type          = var.instance_type
+  iam_instance_profile   = aws_iam_instance_profile.ec2_instance_profile.name
+  user_data              = templatefile("${path.module}/user_data.sh.tpl", { bucket_name = var.bucket_name })
+
+  tags = {
+    Name = "LogUploaderInstance"
+  }
+}

--- a/aws-log-automation/user_data.sh
+++ b/aws-log-automation/user_data.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+yum update -y
+yum install -y awscli
+
+BUCKET_NAME="${bucket_name}"
+APP_LOG_PATH="/var/app/logs"
+SYSTEM_LOG="/var/log/cloud-init.log"
+
+# Create upload script
+cat <<EOF > /opt/upload_logs_on_shutdown.sh
+#!/bin/bash
+aws s3 cp ${SYSTEM_LOG} s3://${bucket_name}/logs/cloud-init.log
+aws s3 cp --recursive ${APP_LOG_PATH} s3://${bucket_name}/logs/app/
+EOF
+
+chmod +x /opt/upload_logs_on_shutdown.sh
+
+# Create systemd service
+cat <<EOF > /etc/systemd/system/log-upload-on-shutdown.service
+[Unit]
+Description=Upload logs to S3 on shutdown
+DefaultDependencies=no
+After=network.target
+
+[Service]
+Type=oneshot
+ExecStart=/opt/upload_logs_on_shutdown.sh
+TimeoutStartSec=0
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
+systemctl enable log-upload-on-shutdown.service

--- a/aws-log-automation/variables.tf
+++ b/aws-log-automation/variables.tf
@@ -8,7 +8,7 @@ variable "bucket_name" {
   description = "Name of the S3 bucket for logs (must be globally unique)"
   type        = string
 }
-
+git 
 variable "instance_type" {
   description = "EC2 instance type"
   type        = string


### PR DESCRIPTION
This PR implements includes:

- Creation of two IAM roles:
  - One with read-only access to a specific S3 bucket.
  - One with write-only permissions to create buckets and upload logs.

- EC2 instance setup using Terraform, with IAM role attached via Instance Profile.
- Private S3 bucket creation with lifecycle rules to auto-delete logs after 7 days.
- EC2 uploads system logs and application logs to S3 on shutdown via a systemd service.
- Read-only role verification script to confirm access to uploaded logs.

